### PR TITLE
Enabling okay button for extensions using quickpick

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
       parallel {
         stage('Test') {
           steps {
-            build 'freestyle 12'
+            build 'freestyle 2'
           }
         }
         stage('QA') {


### PR DESCRIPTION
The goal is to open the right file if you know the class name, which should remove some friction while debugging the failing or flaky texts. This will improve the quality of the testing and increase code quality. The overall stability of the app will be improved significantly with this improvement